### PR TITLE
de-allocate entry via enif_free() when name allocation fails

### DIFF
--- a/c_src/mqtree.c
+++ b/c_src/mqtree.c
@@ -205,7 +205,7 @@ int register_tree(char *name, state_t *state) {
 
   entry->name = enif_alloc(strlen(name) + 1);
   if (!entry->name) {
-    free(entry);
+    enif_free(entry);
     return ENOMEM;
   }
 


### PR DESCRIPTION
In the event that an entry could be allocated, but the name allocation for the entry fails, free the entry with enif_free().

While updating Erlang on Gentoo I noticed the following compiler warning:

c_src/mqtree.c:208:5: warning: ‘free’ called on pointer returned from a mismatched allocation function [-Wmismatched-dealloc]

I'm not familiar with erl_nif, but it looks like this is a legitimate warning and the memory should be freed via the enif_free() interface.